### PR TITLE
package.json version matching that of private_pub itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "private_pub",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "Handle pub/sub messaging through private channels in Rails using Faye.",
   "main": "app/assets/javascripts/private_pub.js",
   "scripts": {


### PR DESCRIPTION
One could argue that you chose to bump the gemspec version to 1.0.4 because you added ERB parsing to the config. In that case the package.json version should also be 1.0.4.

In any case it should be orientated on the packaged private_pub gem with its JavaScript. The current 1.0.0 is misleading, because it ships 1.0.3/1.0.4 and not 1.0.0 of the private_pub gem/JavaScript.